### PR TITLE
fix for version mismatches in Vaadin deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7062,9 +7062,9 @@
       "dev": true
     },
     "levenary": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.0.tgz",
-      "integrity": "sha512-VHcwhO0UTpUW7rLPN2/OiWJdgA1e9BqEDALhrgCe/F+uUJnep6CoUsTzMeP8Rh0NGr9uKquXxqe7lwLZo509nQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.1.tgz",
+      "integrity": "sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==",
       "dev": true,
       "requires": {
         "leven": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "dependencies": {
     "@polymer/polymer": "3.2.0",
     "@webcomponents/webcomponentsjs": "^2.2.10",
-    "@vaadin/flow-deps": "./target/frontend",
-    "@vaadin/vaadin-text-field": "latest",
-    "@vaadin/vaadin-button": "latest"
+    "@vaadin/flow-deps": "./target/frontend"
   },
   "devDependencies": {
     "webpack": "4.30.0",


### PR DESCRIPTION
Vaadin needs to have compatible versions of the components to work.

Package.json said to use all Vaadin components according to the Vaadin version in use, but then it overrode still vaadin-text-field and vaadin-button to a newer version. Combobox imported one version of textfield, while textfield was imported as another version, and the system broke down as it can't use both at the same time. Removed the deps.

Steps to do to fix: 
1. Get this PR
1. Delete `node_modules/`, `target/` and `package-lock.json`. 
1. Run `mvn clean package spring-boot:run`